### PR TITLE
fix title case

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
         </div>
       </section>
       <article class="readable-width">
-        <h2 id="cast-a-wide-net">Cast as wide a net as possible</h2>
+        <h2 id="cast-a-wide-net">Cast As Wide a Net As Possible</h2>
         <div class="comparison">
           <div class="bad">Any JavaScript pros around that can help me?</div>
           <div class="good">I am trying to do <code>X</code> with JavaScript, can someone help?</div>
@@ -193,7 +193,7 @@
           This phenomenon is also know as the "XY Problem"&mdash;the phenomenon where someone wants to do
           <code>X</code> but (incorrectly) thinks they can solve it by doing <code>Y</code>.
         </p>
-        <h2 id="stay-async">Stay in the Asynchronous Communication Channel (if possible)</h2>
+        <h2 id="stay-async">Stay in the Asynchronous Communication Channel (if Possible)</h2>
         <div class="comparison">
           <div class="bad">I need help with <code>X</code>! Can someone join a voice call with me?</div>
           <div class="good">
@@ -226,7 +226,7 @@
           (and thus waste your time) talking about things you would not yet understand. The best way to handle a
           situation like this is to <em>redirect the conversation to what you don't know.</em>
         </p>
-        <h2 id="avoid-being-secretive">Avoid Being Secretive (if possible)</h2>
+        <h2 id="avoid-being-secretive">Avoid Being Secretive (if Possible)</h2>
         <div class="comparison">
           <div class="bad">How do I do <code>X</code>?</div>
           <div class="good">
@@ -245,7 +245,7 @@
           Being secretive also makes helping more difficult because in a secretive project, helpers are likely to lack
           crucial information, preventing them from making informed decisions.
         </p>
-        <h2 id="explain-how-you-did-it">Explain how you Solved your Problem.</h2>
+        <h2 id="explain-how-you-did-it">Explain How You Solved Your Problem</h2>
         <div class="comparison">
           <div class="bad">Nevermind, fixed it!</div>
           <div class="good">
@@ -256,7 +256,7 @@
           If you asked a question in a public forum and later found the solution on your own, explain how you solved it
           so that other people with the same problem can solve it too if they find your question.
         </p>
-        <h2 id="helpers-are-volunteers">Helpers are (often) Volunteers</h2>
+        <h2 id="helpers-are-volunteers">Helpers Are (Often) Volunteers</h2>
         <p>
           In the end, remember that, unless they're getting paid to help you, the people helping you are ultimately
           volunteering their own time to do so, and thus are under no obligation to keep helping you. Don't let this
@@ -286,8 +286,7 @@
           <em>answer</em> questions and have to deal with questions that ignore guidelines like the ones above.
         </p>
         <h2 id="hanlons-razor">
-          Hanlon's Razor: "Never Attribute to Malice what can be Adequately Explained by Ignorance"
-        </h2>
+            <h2>Hanlon’s Razor: “Never Attribute to Malice What Can Be Adequately Explained by Ignorance”</h2>
         <div class="comparison">
           <div class="bad">
             <i
@@ -331,7 +330,7 @@
           In other words, someone breaking these rules is likely doing so because they are applying IRL standards to an
           online forum.
         </p>
-        <h2 id="dont-respond-with-a-link">Don't Respond with a Link to This Site (or others, for that matter)</h2>
+        <h2 id="dont-respond-with-a-link">Don’t Respond With a Link to This Site (or Others, for That Matter)</h2>
         <div class="comparison">
           <div class="bad">
             Don't ask to ask:


### PR DESCRIPTION
Don’t is capitalized because it is the first word of the title.
Respond is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
With is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters. 
a is not capitalized because it is an article. 
Link is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
to is not capitalized because it is probably used as a preposition. However, it can also be used as an adverb (“pull the door to”) or as part of an infinitive (“to do”), in which case it must be capitalized.
This is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
Site is capitalized because it is the last word of the title or subtitle. 
or is not capitalized because it is a conjunction. 
Others is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
for is not capitalized because it seems to be used as a preposition.
That is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters. 
Matter is capitalized because it is the last word of the title or subtitle.



Stay is capitalized because it is the first word of the title.
in is not capitalized because it seems to be used as a preposition.
the is not capitalized because it is an article. 
Asynchronous is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
Communication is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
Channel is capitalized because it is the last word of the title or subtitle. 
if is not capitalized because it is a short subordinating conjunction.
Possible is capitalized because it is the last word of the title or subtitle. 



Avoid is capitalized because it is the first word of the title.
Being is capitalized because it is a verb, and all verbs are capitalized in title case. 
Secretive is capitalized because it is the last word of the title or subtitle.
if is not capitalized because it is a short subordinating conjunction.
Possible is capitalized because it is the last word of the title or subtitle.




Explain is capitalized because it is the first word of the title.
How is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters. 
You is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters. 
Solved is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
Your is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters. 
Problem is capitalized because it is the last word of the title or subtitle.



Helpers is capitalized because it is the first word of the title.
Are is capitalized because it is a verb, and all verbs are capitalized in title case.
Often is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
Volunteers is capitalized because it is the last word of the title or subtitle.



Don’t is capitalized because it is the first word of the title.
Respond is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
With is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
a is not capitalized because it is an article. 
Link is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
to is not capitalized because it is probably used as a preposition. However, it can also be used as an adverb (“pull the door to”) or as part of an infinitive (“to do”), in which case it must be capitalized. 
This is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
Site is capitalized because it is the last word of the title or subtitle.
or is not capitalized because it is a conjunction. 
Others is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
for is not capitalized because it seems to be used as a preposition.
That is capitalized because it is neither an article, a coordinating conjunction nor a preposition with fewer than four letters.
Matter is capitalized because it is the last word of the title or subtitle. 